### PR TITLE
Disable Undefined Behavior Sanitizer - UBSAN

### DIFF
--- a/nvidia-470xx-kmod.spec
+++ b/nvidia-470xx-kmod.spec
@@ -12,7 +12,7 @@ Name:          nvidia-470xx-kmod
 Epoch:         3
 Version:       470.239.06
 # Taken over by kmodtool
-Release:       1%{?dist}
+Release:       2%{?dist}
 
 License:       Redistributable, no modification permitted
 Summary:       NVIDIA 470xx display driver kernel module
@@ -20,6 +20,7 @@ URL:           https://www.nvidia.com/
 
 Source11:      nvidia-470xx-kmodtool-excludekernel-filterfile
 Patch0:        gcc-14.patch
+Patch1:        nvidia-UBSAN.patch
 
 # needed for plague to make sure it builds for i586 and i686
 ExclusiveArch:  x86_64
@@ -43,6 +44,7 @@ kmodtool  --target %{_target_cpu}  --repo rpmfusion --kmodname %{name} --filterf
 %setup -T -c
 tar --use-compress-program xz -xf %{_datadir}/%{name}-%{version}/%{name}-%{version}-%{_target_cpu}.tar.xz
 %patch -P0 -p1
+%patch -P1 -p1
 for kernel_version  in %{?kernel_versions} ; do
     cp -a kernel _kmod_build_${kernel_version%%___*}
 done
@@ -73,6 +75,9 @@ done
 %{?akmod_install}
 
 %changelog
+* Sun May 05 2024 Giannis Kapetanakis <bilias@edu.physics.uoc.gr> - 3:470.239.06-2
+- Disable Undefined Behavior Sanitizer - UBSAN
+
 * Mon Apr 15 2024 Sérgio Basto <sergio@serjux.com> - 3:470.239.06-1
 - Update nvidia-470xx-kmod to 470.239.06
 

--- a/nvidia-UBSAN.patch
+++ b/nvidia-UBSAN.patch
@@ -1,0 +1,11 @@
+--- a/kernel/Kbuild
++++ b/kernel/Kbuild
+@@ -53,6 +53,8 @@
+ NV_UNDEF_BEHAVIOR_SANITIZER ?=
+ ifeq ($(NV_UNDEF_BEHAVIOR_SANITIZER),1)
+  UBSAN_SANITIZE := y
++else
++ UBSAN_SANITIZE := n
+ endif
+ 
+ $(foreach _module, $(NV_KERNEL_MODULES), \


### PR DESCRIPTION
Fedora F40 in kernel 6.8.8 enabled UBSAN
https://www.kernel.org/doc/html/v4.19/dev-tools/ubsan.html
https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
https://forums.developer.nvidia.com/t/ubsan-array-index-out-of-bounds-complaints-in-newer-kernels/271705

grep -w CONFIG_UBSAN /boot/config-6.8.*
/boot/config-6.8.7-300.fc40.x86_64:# CONFIG_UBSAN is not set
/boot/config-6.8.8-300.fc40.x86_64:CONFIG_UBSAN=y

This creates a trace with NVIDIA.
[dmesg.txt](https://github.com/rpmfusion/nvidia-470xx-kmod/files/15212514/dmesg.txt)
ie:
[   12.771544] UBSAN: array-index-out-of-bounds in /tmp/akmodsbuild.jZjipAB2/BUILD/nvidia-470xx-kmod-470.239.06/_kmod_build_6.8.8-300.fc40.x86_64/nvidia-uvm/uvm_pmm_gpu.c:2277:28
[   12.771546] index 0 is out of range for type 'uvm_gpu_chunk_t *[*]'
...

This patch explicitly disables UBSAN checks for nvidia modules in the Kbuild.
I've tried to disable it only for nvidia-uvm but didn't work. Didn't persist on it.

Ideally, the source code should be updated to convert structures to use C99 flexible array members.
See for instance a patch for a different driver but same problem here:
https://gist.github.com/joanbm/9cd5fda1dcfab9a67b42cc6195b7b269

Tested it with Fedora 40 and 6.8.8-300.fc40.x86_64 on GK106 [GeForce GTX 660]

Trace gone.